### PR TITLE
treat units properly

### DIFF
--- a/checks/resources.py
+++ b/checks/resources.py
@@ -1,4 +1,5 @@
 from lib.base import CheckBase
+from lib.units import mem_to_bytes, cpu_to_millicores
 
 
 class CheckResources(CheckBase):
@@ -81,6 +82,14 @@ class CheckBestEffort(CheckResources):
             assert mem_req, error_msg('Expecting requests/memory')
             assert mem_lim, error_msg('Expecting limits/memory')
 
-            # ensure reqs is smaller than limits
-            assert cpu_req < cpu_lim, error_msg('Expecting cpu_req < cpu_lim')
-            assert mem_req < mem_lim, error_msg('Expecting mem_req < mem_lim')
+            # ensure reqs are smaller than limits
+            cpu_msg = 'Expecting cpu_req ({}) < cpu_lim ({})'.format(
+                cpu_req, cpu_lim)
+
+            assert cpu_to_millicores(cpu_req) < cpu_to_millicores(cpu_lim), \
+                cpu_msg
+
+            mem_msg = 'Expecting mem_req ({}) < mem_lim ({})'.format(
+                mem_req, mem_lim)
+
+            assert mem_to_bytes(mem_req) < mem_to_bytes(mem_lim), mem_msg

--- a/lib/units.py
+++ b/lib/units.py
@@ -1,0 +1,44 @@
+import re
+
+
+def mem_to_bytes(mem):
+    if isinstance(mem, (float, int)):
+        return mem
+
+    """ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory """
+    m = re.match(r"^((?:0|[1-9]\d*)(?:\.\d+)?)\s*([A-Za-z]+)?$", mem)
+
+    if m is None:
+        raise Exception("Invalid memory format: {}".format(mem))
+
+    val = float(m.group(1))
+    unit = m.group(2)
+
+    if unit is None:
+        return int(val)
+
+    units = ['K', 'M', 'G', 'T', 'P', 'E']
+    if unit in units:
+        return int(val * 10**((units.index(unit) + 1) * 3))
+
+    binary_units = ['Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei']
+    if unit in binary_units:
+        return int(val * 1024**(binary_units.index(unit) + 1))
+
+    raise Exception("Unknown unit: {}".format(unit))
+
+
+def cpu_to_millicores(cpu):
+    try:
+        m = re.match(r"^([1-9]\d*)m$", cpu)
+        if m:
+            return int(m.group(1))
+    except TypeError:
+        pass
+
+    try:
+        cores = float(cpu)
+    except ValueError:
+        raise Exception('Invalid cpu format: {}'.format(cpu))
+
+    return int(cores * 1000)

--- a/lib/units.py
+++ b/lib/units.py
@@ -5,7 +5,6 @@ def mem_to_bytes(mem):
     if isinstance(mem, (float, int)):
         return mem
 
-    """ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory """
     m = re.match(r"^((?:0|[1-9]\d*)(?:\.\d+)?)\s*([A-Za-z]+)?$", mem)
 
     if m is None:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,37 @@
+import pytest
+
+from lib.units import mem_to_bytes, cpu_to_millicores
+
+
+def test_mem_to_bytes():
+    with pytest.raises(Exception):
+        assert mem_to_bytes('1 ble')
+
+    with pytest.raises(Exception):
+        assert mem_to_bytes('x10 Mi')
+
+    assert mem_to_bytes('10') == 10
+    assert mem_to_bytes(10) == 10
+    assert mem_to_bytes('1K') == 1000
+    assert mem_to_bytes('1Ki') == 1024
+    assert mem_to_bytes('2 Ki') == 2048
+    assert mem_to_bytes('1M') == 1000000
+    assert mem_to_bytes('0.5M') == 500000
+    assert mem_to_bytes('12 M') == 12000000
+    assert mem_to_bytes('1Mi') == 1048576
+    assert mem_to_bytes('0.5 Mi') == 524288
+    assert mem_to_bytes('17 Gi') == 18253611008
+    assert mem_to_bytes('17 G') == 17000000000
+
+
+def test_cpu_to_millicores():
+    with pytest.raises(Exception):
+        assert cpu_to_millicores('1 ble')
+
+    with pytest.raises(Exception):
+        assert mem_to_bytes('123.1m')
+
+    assert cpu_to_millicores('1') == 1000
+    assert cpu_to_millicores(1) == 1000
+    assert cpu_to_millicores('0.01') == 10
+    assert cpu_to_millicores('1m') == 1


### PR DESCRIPTION
The CheckBestEffort was failing previously because in order to check that the reqs < limits we were comparing the values directly, and that doesn't work because some values have suffixes:

```
In [1]: '256Mi' < '1536Mi'                                                                                                                                                    
Out[1]: False
```

Which is of course wrong.

This PR introduces two new methods `mem_to_bytes` and `cpu_to_millicores` to convert to a well-known unit before making the comparison.