### PR TITLE
Add PrometheusRule checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ A tool to perform checks on kubernetes/openshift manifests.
 
 ```
 usage: manifest-bouncer [-h] [-v] [--warn-only] [--enable-all] [--disable-all]
-                        [--enable-rbac] [--enable-registry-quay]
-                        [--enable-limits] [--enable-requests]
-                        [--enable-burstable]
+                        [--enable-prometheus-rule-severity]
+                        [--enable-public-resources] [--enable-rbac]
+                        [--enable-registry-quay] [--enable-limits]
+                        [--enable-requests] [--enable-burstable]
                         MANIFEST
 
 Run checks on k8s/openshift manifests.
@@ -27,9 +28,15 @@ optional arguments:
                         the `--disable-<check>` form.
   --disable-all         Don't run any checks. To enable a specific check, use
                         the `--enable-<check>` form.
+  --enable-prometheus-rule-severity, --disable-prometheus-rule-severity
+                        check that PrometheusRule severity is in allowed
+                        values (Default: ENABLED)
+  --enable-public-resources, --disable-public-resources
+                        check that all data in a resource is public (Default:
+                        DISABLED)
   --enable-rbac, --disable-rbac
                         check that Roles are listed before RoleBindings
-                        (Default: ENABLED)
+                        (Default: DISABLED)
   --enable-registry-quay, --disable-registry-quay
                         check that all the images are hosted in quay.io
                         (Default: ENABLED)
@@ -88,16 +95,16 @@ python3 -m venv venv
 source venv/bin/activate
 
 # make sure you are running the latest setuptools
-pip install --upgrade pip setuptools
+python3 -m pip install --upgrade pip setuptools
 ```
 
 Install the package:
 
 ```sh
-python setup.py install
+python3 setup.py install
 
 # or alternatively use this for a devel environment
-python setup.py develop
+python3 setup.py develop
 ```
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A tool to perform checks on kubernetes/openshift manifests.
 ```
 usage: manifest-bouncer [-h] [-v] [--warn-only] [--enable-all] [--disable-all]
                         [--enable-prometheus-rule-severity]
+                        [--enable-prometheus-rule-labels]
                         [--enable-public-resources] [--enable-rbac]
                         [--enable-registry-quay] [--enable-limits]
                         [--enable-requests] [--enable-burstable]
@@ -31,6 +32,9 @@ optional arguments:
   --enable-prometheus-rule-severity, --disable-prometheus-rule-severity
                         check that PrometheusRule severity is in allowed
                         values (Default: ENABLED)
+  --enable-prometheus-rule-labels, --disable-prometheus-rule-labels
+                        check that required PrometheusRule labels are set
+                        (Default: ENABLED)
   --enable-public-resources, --disable-public-resources
                         check that all data in a resource is public (Default:
                         DISABLED)

--- a/checks/prometheus_rule.py
+++ b/checks/prometheus_rule.py
@@ -1,0 +1,29 @@
+from lib.base import CheckBase
+
+
+class CheckPrometheusRuleSeverity(CheckBase):
+    whitelist = ['PrometheusRule']
+
+    enable_parameter = 'prometheus-rule-severity'
+    description = 'check that PrometheusRule severity is in allowed values'
+    default_enabled = True
+
+    def check_severity(self, m):
+        allowed_severities = ['high', 'warning', 'medium', 'info']
+        fmt = "[{}/{}/{}] severity '{}' should be one of: {}"
+
+        resource_name = m['metadata']['name']
+        groups = m['spec']['groups']
+        for group in groups:
+            group_name = group['name']
+            rules = group['rules']
+            for rule in rules:
+                alert = rule['alert']
+                labels = rule.get('labels', {})
+                severity = labels.get('severity', '')
+                msg = fmt.format(resource_name,
+                                 group_name,
+                                 alert,
+                                 severity,
+                                 allowed_severities)
+                assert severity in allowed_severities, msg

--- a/checks/prometheus_rule.py
+++ b/checks/prometheus_rule.py
@@ -27,3 +27,21 @@ class CheckPrometheusRuleSeverity(CheckBase):
                                  severity,
                                  allowed_severities)
                 assert severity in allowed_severities, msg
+
+
+class CheckPrometheusRuleLabels(CheckBase):
+    whitelist = ['PrometheusRule']
+
+    enable_parameter = 'prometheus-rule-labels'
+    description = 'check that required PrometheusRule labels are set'
+    default_enabled = True
+
+    def check_labels(self, m):
+        required_labels = {'prometheus': 'app-sre', 'role': 'alert-rules'}
+        fmt = "[{}] labels should contain: {}"
+
+        resource_name = m['metadata']['name']
+        labels = m['metadata'].get('labels', {})
+
+        msg = fmt.format(resource_name, required_labels)
+        assert required_labels.items() <= labels.items(), msg

--- a/tests/test_prometheus_rules.py
+++ b/tests/test_prometheus_rules.py
@@ -1,0 +1,50 @@
+import yaml
+from textwrap import dedent
+
+from checks.prometheus_rule import (CheckPrometheusRuleSeverity,
+                                    CheckPrometheusRuleLabels)
+from lib.result import CheckError, CheckSuccess
+
+
+def test_prometheus_rule_severity_valid():
+    manifest = yaml.safe_load(dedent("""
+    ---
+    apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+        name: rule
+    spec:
+        groups:
+        - name: group
+          rules:
+          - alert: alert
+            labels:
+                severity: high
+    """))
+
+    c = CheckPrometheusRuleSeverity()
+
+    result = c.check_severity(manifest)
+    assert isinstance(result, CheckSuccess)
+
+
+def test_prometheus_rule_severity_invalid():
+    manifest = yaml.safe_load(dedent("""
+    ---
+    apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+        name: rule
+    spec:
+        groups:
+        - name: group
+          rules:
+          - alert: alert
+            labels:
+                severity: critical
+    """))
+
+    c = CheckPrometheusRuleSeverity()
+
+    result = c.check_severity(manifest)
+    assert isinstance(result, CheckError)

--- a/tests/test_prometheus_rules.py
+++ b/tests/test_prometheus_rules.py
@@ -48,3 +48,39 @@ def test_prometheus_rule_severity_invalid():
 
     result = c.check_severity(manifest)
     assert isinstance(result, CheckError)
+
+
+def test_prometheus_rule_labels_valid():
+    manifest = yaml.safe_load(dedent("""
+    ---
+    apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+        name: rule
+        labels:
+            prometheus: app-sre
+            role: alert-rules
+    """))
+
+    c = CheckPrometheusRuleLabels()
+
+    result = c.check_labels(manifest)
+    assert isinstance(result, CheckSuccess)
+
+
+def test_prometheus_rule_labels_invalid():
+    manifest = yaml.safe_load(dedent("""
+    ---
+    apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+        name: rule
+        labels:
+            promethues: app-sre
+            role: alert-rules
+    """))
+
+    c = CheckPrometheusRuleLabels()
+
+    result = c.check_labels(manifest)
+    assert isinstance(result, CheckError)


### PR DESCRIPTION
This PR adds the following checks:
- check that severity is not `critical` - to keep us in the loop on alerts that may wake us, these should only go via app-interface.
- check that labels are set correctly - so the alert are ingested in our monitoring stack. this one may be removed or changed if the team doesn't like `'prometheus': 'app-sre'`.

This will allow us to deploy `PrometheusRule`s from upstream while staying in control of what keeps us up at night.