### PR TITLE
Move to UBI8 base image based on python 3.8

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,7 +1,6 @@
-FROM python:3.7.4
+FROM registry.access.redhat.com/ubi8/python-38
 
-ADD . /package
-WORKDIR /package
+ADD . .
 
 RUN python setup.py install
 

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,9 +1,8 @@
-FROM python:3.7.4
+FROM registry.access.redhat.com/ubi8/python-38
 
 RUN pip install tox
 
-ADD . /package
-WORKDIR /package
+ADD . .
 
 RUN python setup.py install
 

--- a/tests/test_public_resources.py
+++ b/tests/test_public_resources.py
@@ -65,6 +65,7 @@ def test_check_public_deployment_valid():
     result = c.check_public_resource(manifest)
     assert isinstance(result, CheckSuccess)
 
+
 def test_check_public_deployment_invalid():
     manifest = yaml.safe_load(dedent("""
     ---

--- a/tests/test_registry_quay.py
+++ b/tests/test_registry_quay.py
@@ -133,6 +133,7 @@ def test_check_registry_quay_init_container():
     result = c.check_registry_quay(manifest)
     assert isinstance(result, CheckSuccess)
 
+
 def test_check_registry_quay_cron_job():
     manifest = yaml.safe_load(dedent("""
     ---

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist = flake8, py38
 [testenv]
 commands = pytest
 deps =
-    pytest==5.1.2
+    pytest==6.1.0
     anymarkup==0.8.1
 
 [testenv:flake8]
 commands = flake8 manifest_bouncer.py lib checks
-deps = flake8==3.7.8
+deps = flake8==3.8.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py37
+envlist = flake8, py38
 
 [testenv]
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ deps =
     anymarkup==0.8.1
 
 [testenv:flake8]
-commands = flake8 manifest_bouncer.py lib checks
+commands = flake8 checks cli lib tests
 deps = flake8==3.8.3


### PR DESCRIPTION
This PRs main goal is to change the base image to a supported image, in this case an UBI8 base image.

The PR also includes the following:
- Upgrade to python 3.8 (3.7 is not available in UBI8)
- Update the tox config as follow:
  - Use py38 environment
  - bump pytest and flake8 dependencies (while I believe not explicitly required, I felt this was a good opportunity to do so)
  - update flake8 targets, remove invalid `manifest_bouncer.py` and add missing `cli` and `tests` modules for complete coverage
- fix minor flake8 errors found in newly added flake8 targets